### PR TITLE
Add bullet as development dependency

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -34,6 +34,7 @@ end
 
 group :development, :test do
   gem "awesome_print"
+  gem "bullet"
   gem "bundler-audit", require: false
   gem "byebug"
   gem "dotenv-rails"


### PR DESCRIPTION
Bullet notifies automatically if there is any request in the application
where we are performing N+1 queries, or unused eager loading.

With this check we make sure we eager load what is needed, and nothing
more, without having to check each endpoint.

To do:

- [ ] Add configuration to development and test environments+suspenders